### PR TITLE
Fix typo in widget gallery README

### DIFF
--- a/examples/widget-gallery/README.md
+++ b/examples/widget-gallery/README.md
@@ -5,7 +5,7 @@
 - Classical HTML form
 - HTML form with ajax request
 
-## Prerequesites
+## Prerequisites
 
 - Setup an active conduit using `conduit-server`
 - Run the `proxy-server` under PORT `80`


### PR DESCRIPTION
## Summary
- fix `Prerequisites` heading typo in examples widget README

## Testing
- `git status --short`
