### PR TITLE
Fix promise resolution in afetch

### DIFF
--- a/backend/lib/afetch.js
+++ b/backend/lib/afetch.js
@@ -148,7 +148,7 @@ async function afetch(host, options) {
         // response regardless of the status will be in json format; if this
         // is not the case then the developer has the option to use a function.
         if (onNotOk === 'resolve') {
-          Promise.resolve({
+          return Promise.resolve({
             status: response.status,
             data: await response.json(),
           });


### PR DESCRIPTION
## Summary
- ensure `afetch` resolves non-OK responses

## Testing
- `npm run test-gateway --silent` *(fails: `mocha` not found)*
- `npm run lint-lib --silent` *(fails: ESLint config missing)*