### PR TITLE
Fix dashboard index html for Vite

### DIFF
--- a/dashboard/src/web/index.html
+++ b/dashboard/src/web/index.html
@@ -6,19 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Keep your data to yourself">
   <title>Conduits</title>
-  <!--
-    See https://stackoverflow.com/questions/45321043/preload-css-file-not-supported-on-firefox-and-safari-mac
-    Unfortunately adding the suggested solution breaks the webpack inline css plugin
-    Solution is to not preload css until it is widely supported OR the plugin gets fixed
-    OR to fix the plugin in your local copy.
-
-    Follow https://github.com/Runjuu/html-inline-css-webpack-plugin/issues/10 for
-    the fix and the local fix.
-  -->
-  <% for (var chunk in htmlWebpackPlugin.files.css) { %>
-  <link href="<%= htmlWebpackPlugin.files.css[chunk] %>" as="style" rel="preload">
-  <link href="<%= htmlWebpackPlugin.files.css[chunk] %>" rel="stylesheet">
-  <% } %>
+  <link rel="stylesheet" href="/src/app/main.scss">
 
 
   <!-- stuff that we know a priori to exist in the app -->
@@ -28,16 +16,9 @@
 
 <body>
   <div id="root">
-    <!--
-      NOTE: webpack-html-plugin will stuff the compiled js and css chunks
-      into this file automagically!
-    -->
     Loading...
   </div>
-  <% for (var chunk in htmlWebpackPlugin.files.js) { %>
-  <script type="text/javascript" src="<%= htmlWebpackPlugin.files.js[chunk] %>">
-  </script>
-  <% } %>
+  <script type="module" src="/src/app/main.js"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- update `dashboard/src/web/index.html` for Vite static assets

## Testing
- `npm test` *(fails: stylelint not found)*